### PR TITLE
drop conda in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,15 @@ jobs:
     - uses: actions/checkout@v2
     # set up conda
     - name: Set up Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
+      uses: actions/setup-python@v4
       with:
-        auto-activate-base: true
-        activate-environment: ""
+        python-version: ${{ matrix.python-version }}
     # install rdkit and openbabel
     - name: Install rdkit
-      run: conda create -c conda-forge -n my-rdkit-env python=${{ matrix.python-version }} rdkit openbabel;
+      run: python -m pip install rdkit openbabel-wheel
     - name: Install dependencies
-      run: source $CONDA/bin/activate my-rdkit-env && pip install .[amber,ase,pymatgen] coverage codecov
+      run: python -m pip install .[amber,ase,pymatgen] coverage codecov
     - name: Test
-      run: source $CONDA/bin/activate my-rdkit-env && cd tests && coverage run --source=../dpdata -m unittest && cd .. && coverage combine tests/.coverage && coverage report
+      run: cd tests && coverage run --source=../dpdata -m unittest && cd .. && coverage combine tests/.coverage && coverage report
     - name: Run codecov
-      run: source $CONDA/bin/activate my-rdkit-env && codecov
+      run: codecov


### PR DESCRIPTION
Here we use `pip install` instead, as it's faster than `conda install`.

On the PyPI, `rdkit` package has been released officially. `openbabel-wheel` was made by me.